### PR TITLE
nginx_user is now a default variable, instead of a forced one

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+nginx_user: "nginx"
 nginx_remove_default_vhost: false
 nginx_default_vhost_path: /etc/nginx/sites-enabled/default

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,4 @@
 ---
-nginx_user: "nginx"
 nginx_worker_processes: "1"
 nginx_worker_connections: "8192"
 nginx_client_max_body_size: "64m"


### PR DESCRIPTION
This is linked to the github issue of the same name.
