### PR TITLE
Move vars to defaults as otherwise they may not be overridden.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,8 @@
 ---
+nginx_user: "nginx"
+nginx_worker_processes: "1"
+nginx_worker_connections: "8192"
+nginx_client_max_body_size: "64m"
+nginx_keepalive_timeout: "65"
 nginx_remove_default_vhost: false
 nginx_default_vhost_path: /etc/nginx/sites-enabled/default

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,1 @@
 ---
-nginx_user: "nginx"
-nginx_worker_processes: "1"
-nginx_worker_connections: "8192"
-nginx_client_max_body_size: "64m"
-nginx_keepalive_timeout: "65"


### PR DESCRIPTION
In the example playbook a lot of the variables are overridden in `vars/main.yml`, however these values are not picked up because they are not in `defaults/main.yml`, see #3 as well.
