### PR TITLE
Added additional nginx_conf_path for Debian

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -51,6 +51,6 @@ http {
     include {{ nginx_conf_path }};
 {% endif %}
 {% if nginx_vhost_path is defined %}
-    include {{ nginx_vhost_path }};
+    include {{ nginx_vhost_path }}/*;
 {% endif %}
 }

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -47,5 +47,10 @@ http {
     }
 {% endfor %}
 
-    include {{ nginx_vhost_path }}/*;
+{% if nginx_conf_path is defined %}
+    include {{ nginx_conf_path }};
+{% endif %}
+{% if nginx_vhost_path is defined %}
+    include {{ nginx_vhost_path }};
+{% endif %}
 }

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,5 @@
 ---
 nginx_conf_path: /etc/nginx/conf.d/*.conf
-nginx_vhost_path: /etc/nginx/sites-enabled/*
+nginx_vhost_path: /etc/nginx/sites-enabled
 nginx_default_vhost_path: /etc/nginx/sites-enabled/default
 __nginx_user: "www-data"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,5 @@
 ---
-nginx_vhost_path: /etc/nginx/sites-enabled
+nginx_conf_path: /etc/nginx/conf.d/*.conf
+nginx_vhost_path: /etc/nginx/sites-enabled/*
 nginx_default_vhost_path: /etc/nginx/sites-enabled/default
 __nginx_user: "www-data"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,4 @@
 ---
-nginx_vhost_path: /etc/nginx/conf.d
+nginx_vhost_path: /etc/nginx/conf.d/*
 nginx_default_vhost_path: /etc/nginx/conf.d/default.conf
 __nginx_user: "nginx"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,4 @@
 ---
-nginx_vhost_path: /etc/nginx/conf.d/*
+nginx_vhost_path: /etc/nginx/conf.d
 nginx_default_vhost_path: /etc/nginx/conf.d/default.conf
 __nginx_user: "nginx"


### PR DESCRIPTION
For Debian systems both conf.d and sites-enabled should be included by default. Redhat systems have not been changed.

Issues came up using Kibana on Ubuntu as it installs kibana.conf in the conf.d folder.