### PR TITLE
Fix nginx_vhosts comment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ nginx_vhosts: []
 #   # Properties that are only added if defined:
 #   error_page: "",
 #   access_log: "",
-#   extra_config: "" # Can be used to add extra config blocks (multiline).
+#   extra_parameters: "" # Can be used to add extra config blocks (multiline).
 # }
 
 nginx_upstreams: []


### PR DESCRIPTION
The key used in the vhosts.j2 template is extra_parameters.