### PR TITLE
Remove unnecessary semicolon from vhosts config

### DIFF
--- a/templates/vhosts.j2
+++ b/templates/vhosts.j2
@@ -18,7 +18,7 @@ server {
     {% endif %}
 
     {% if vhost.extra_parameters is defined %}
-    {{ vhost.extra_parameters }};
+    {{ vhost.extra_parameters }}
     {% endif %}
 }
 {% endfor %}


### PR DESCRIPTION
Remove semicolon after `{{ vhost.extra_parameters }}` to allow support for blocks like
```
location ~ \.php$ {
    ...
}
```
which would otherwise fail with a trailing semicolon.