### PR TITLE
Accommodate "missing" ansible_distribution_major_version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: Nginx installation for Linux/UNIX.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 1.4
+  min_ansible_version: 1.6
   platforms:
   - name: EL
     versions:

--- a/templates/nginx.repo.j2
+++ b/templates/nginx.repo.j2
@@ -1,5 +1,5 @@
 [nginx]
 name=nginx repo
-baseurl=http://nginx.org/packages/centos/{{ ansible_distribution_major_version }}/$basearch/
+baseurl=http://nginx.org/packages/centos/{{ ansible_distribution_major_version | regex_replace('^[^0-9]+$', '6') }}/$basearch/
 gpgcheck=0
 enabled=1


### PR DESCRIPTION
Amazon Linux AMI is a member of the 'RedHat' os_family but returns a "NA" major_version. RHEL/Centos 6 is appropriate for Amazon linux, and is likely a safe default for other RedHat derived OS' that return "NA"