### PR TITLE
Collective config validation & "extra options"

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ This value determines the largest file upload possible, as uploads are passed th
 
 Set as the `proxy_cache_path` directive in the `nginx.conf` file. By default, this will not be configured (if left as an empty string), but if you wish to use Nginx as a reverse proxy, you can set this to a valid value (e.g. `"/var/cache/nginx keys_zone=cache:32m"`) to use Nginx's cache (further proxy configuration can be done in individual server configurations).
 
+    nginx_extra_options: ""
+Optionally define extra parameters and their values to be insterted in the top-level `http` block in `nginx.conf`. The value should be defined literally (as you would insert it directly in the `nginx.conf`, adhering to the Nginx configuration syntax - such as `;` for line termination, etc.), like so:
+
+    nginx_extra_options: |
+      proxy_buffering    off;
+      proxy_set_header   X-Real-IP $remote_addr;
+      proxy_set_header   X-Scheme $scheme;
+      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header   Host $http_host;	
+
     nginx_default_release: ""
 
 (For Debian/Ubuntu only) Allows you to set a different repository for the installation of Nginx. As an example, if you are running Debian's wheezy release, and want to get a newer version of Nginx, you can install the `wheezy-backports` repository and set that value here, and Ansible will use that as the `-t` option while installing Nginx.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,13 @@ nginx_client_max_body_size: "64m"
 nginx_proxy_cache_path: ""
 
 nginx_extra_options: ""
+# Example extra options
+#    nginx_extra_options: |
+#      proxy_buffering    off;
+#      proxy_set_header   X-Real-IP $remote_addr;
+#      proxy_set_header   X-Scheme $scheme;
+#      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header   Host $http_host;	
 
 nginx_remove_default_vhost: false
 nginx_vhosts: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,8 @@ nginx_client_max_body_size: "64m"
 
 nginx_proxy_cache_path: ""
 
+nginx_extra_options: ""
+
 nginx_remove_default_vhost: false
 nginx_vhosts: []
 # Example vhost below, showing all available options:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: restart nginx
   service: name=nginx state=restarted
+
+- name: validate nginx configuration
+  command: nginx -t -c /etc/nginx.conf
+  changed_when: False

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,5 @@
   service: name=nginx state=restarted
 
 - name: validate nginx configuration
-  command: nginx -t -c /etc/nginx.conf
+  command: nginx -t -c /etc/nginx/nginx.conf
   changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,9 @@
     group: root
     mode: 0644
     validate: 'nginx -t -c %s'
-  notify: restart nginx
+  notify:
+    - validate nginx configuration
+    - restart nginx
 
 - name: Ensure nginx is started and enabled to start at boot.
   service: name=nginx state=started enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,9 @@
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
+# Vhost configuration
+- include: vhosts.yml
+
 # Nginx setup.
 - name: Copy nginx configuration in place.
   template:
@@ -23,9 +26,8 @@
     owner: root
     group: root
     mode: 0644
+  validate: 'nginx -t -c %s'
   notify: restart nginx
 
 - name: Ensure nginx is started and enabled to start at boot.
   service: name=nginx state=started enabled=yes
-
-- include: vhosts.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
     owner: root
     group: root
     mode: 0644
-  validate: 'nginx -t -c %s'
+    validate: 'nginx -t -c %s'
   notify: restart nginx
 
 - name: Ensure nginx is started and enabled to start at boot.

--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -12,11 +12,16 @@
     dest: "{{ nginx_vhost_path }}/vhosts.conf"
     mode: 0644
   when: nginx_vhosts|length > 0
-  notify: restart nginx
+  notify:
+    - validate nginx configuration
+    - restart nginx
 
 - name: Remove managed vhost config file (if no vhosts are configured).
   file:
     path: "{{ nginx_vhost_path }}/vhosts.conf"
     state: absent
   when: nginx_vhosts|length == 0
-  notify: restart nginx
+  notify:
+    - validate nginx configuration
+    - restart nginx
+

--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -4,7 +4,9 @@
     path: "{{ nginx_default_vhost_path }}"
     state: absent
   when: nginx_remove_default_vhost
-  notify: restart nginx
+  notify:
+    - validate nginx configuration
+    - restart nginx
 
 - name: Add managed vhost config file (if any vhosts are configured).
   template:

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -36,6 +36,10 @@ http {
     proxy_cache_path {{ nginx_proxy_cache_path }};
 {% endif %}
 
+{% if nginx_extra_options %}
+    {{ nginx_extra_options }}
+{% endif %}
+
 {% for upstream in nginx_upstreams %}
     upstream {{ upstream.name }} {
 {% if upstream.strategy is defined %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -37,7 +37,7 @@ http {
 {% endif %}
 
 {% if nginx_extra_options %}
-    {{ nginx_extra_options }}
+        {{ nginx_extra_options }}
 {% endif %}
 
 {% for upstream in nginx_upstreams %}


### PR DESCRIPTION
Hey Jeff!

Thanks for the great role :+1:
Hoping you'll happily accept these contributions (with any modifications you see fit, of course).

These changes bring a collective validation of the deployed Nginx configuration and the option to define arbitrary "extra" configuration options for the top-level `http` block in `/etc/nginx.conf`.

1. Nginx master config validation: I added a `validate` param on the deployment of the `/etc/nginx.conf` file. This will ensure the Nginx config (including any included configs) are valid, according to `nginx -t`. I had to move the deployment of vhosts above the deployment of the `nginx.conf` file, to ensure all config was in place before testing (see my commit message on cc5114d for more details).

2. Nginx config validation handler: I added a handler that will also validate the collective Nginx configuration and have ensured this is triggered anywhere that `restart nginx` was being called.
If an invalid configuration is deployed, it will run this notifier first, so, in the case that `/etc/nginx.conf` doesn't change, but a vhost config does, and as such does not trigger the above mentioned `validate` param, and it introduces some bad config, Ansible will fail upon running the validate handler, so it'll exit before it has a chance (fail) to restart the Nginx service - meaning, you're at least not left with a broken web server :)

3. I added a `nginx_extra_options` variable that will allow the user to define (literally, using Nginx syntax) extra configuration they want to add to the `http` block. I elaborate on this in the commit: c5a2143, in the README, and lastly in an example comment in `defaults/main.yml`.