### PR TITLE
Only add root if it's defined

### DIFF
--- a/templates/vhosts.j2
+++ b/templates/vhosts.j2
@@ -3,7 +3,10 @@ server {
     listen {{ vhost.listen | default('80 default_server') }};
     server_name {{ vhost.server_name }};
 
+    {% if vhost.root is defined %}
     root {{ vhost.root }};
+    {% endif %}
+
     index {{ vhost.index | default('index.html index.htm') }};
 
     {% if vhost.error_page is defined %}


### PR DESCRIPTION
There are instances where `root` isn't needed - for example, if I'm adding a server block to redirect from HTTP to HTTPS.

This PR makes `root` optional, and only adds it to the vhost if it's been added.