### PR TITLE
Validation of nginx.conf fails if it have includes of pre-defined files (like fastcgi_params)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
     owner: root
     group: root
     mode: 0644
-    validate: 'nginx -t -c %s'
+#    validate: 'nginx -t -c %s'
   notify:
     - validate nginx configuration
     - restart nginx


### PR DESCRIPTION
Refer to https://github.com/geerlingguy/ansible-role-nginx/issues/39 