### PR TITLE
Remove new config validation, Fix #41

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,6 @@
 - name: validate nginx configuration
   command: nginx -t -c /etc/nginx/nginx.conf
   changed_when: False
+
+- name: reload nginx
+  service: name=nginx state=reloaded

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,10 +26,8 @@
     owner: root
     group: root
     mode: 0644
-    validate: 'nginx -t -c %s'
   notify:
-    - validate nginx configuration
-    - restart nginx
+    - reload nginx
 
 - name: Ensure nginx is started and enabled to start at boot.
   service: name=nginx state=started enabled=yes

--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -5,8 +5,7 @@
     state: absent
   when: nginx_remove_default_vhost
   notify:
-    - validate nginx configuration
-    - restart nginx
+    - reload nginx
 
 - name: Add managed vhost config file (if any vhosts are configured).
   template:
@@ -15,8 +14,7 @@
     mode: 0644
   when: nginx_vhosts|length > 0
   notify:
-    - validate nginx configuration
-    - restart nginx
+    - reload nginx
 
 - name: Remove managed vhost config file (if no vhosts are configured).
   file:
@@ -24,6 +22,5 @@
     state: absent
   when: nginx_vhosts|length == 0
   notify:
-    - validate nginx configuration
-    - restart nginx
+    - reload nginx
 


### PR DESCRIPTION
NOTE: current nginx config validation process breaks SELinux context
for pid file, as described in #41

Restart of nginx is not needed for configuration changes and is
replaced with reload, which will validate config before applying it,
leaving running nginx process untouched in case of any validation
errors.

Restart handler left in support.