### PR TITLE
Adding in ability to use nginx-extras, useful with @perusio drupal-wi…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 # Used only for Debian/Ubuntu installation, as the -t option for apt.
 nginx_default_release: ""
 
+# Used only for Debian/Ubuntu, added to choose different pkg files.
+nginx_package: "nginx"
+
 nginx_worker_processes: "1"
 nginx_worker_connections: "1024"
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,6 +4,6 @@
 
 - name: Ensure nginx is installed.
   apt:
-    pkg: nginx
+    pkg: "{{ nginx_package }}"
     state: installed
     default_release: "{{ nginx_default_release }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,5 @@
 ---
+nginx_package: nginx
 nginx_conf_path: /etc/nginx/conf.d
 nginx_vhost_path: /etc/nginx/sites-enabled
 nginx_default_vhost_path: /etc/nginx/sites-enabled/default

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,4 @@
 ---
-nginx_package: nginx
 nginx_conf_path: /etc/nginx/conf.d
 nginx_vhost_path: /etc/nginx/sites-enabled
 nginx_default_vhost_path: /etc/nginx/sites-enabled/default


### PR DESCRIPTION
It would be useful to add in the ability to use ```nginx_extras``` which is used with Perusio's [Nginx-with-Drupal config](https://github.com/perusio/drupal-with-nginx)