### PR TITLE
add official nginx ppa for ubuntu

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,3 +50,6 @@ nginx_upstreams: []
 #     "srv2.example.com weight=3",
 #     "srv3.example.com"
 #   }
+
+nginx_ppa_version: stable
+nginx_use_ppa: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,9 @@
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
+- include: setup-Ubuntu.yml
+  when: ansible_distribution == 'Ubuntu'
+
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -1,0 +1,11 @@
+---
+  - name: Add PPA for Nginx.
+    apt_repository: repo='ppa:nginx/{{ nginx_ppa_version }}' state=present update_cache=yes
+    register: added_ppa
+    when: nginx_use_ppa
+
+  - name: ensure nginx is not installed when the ppa was just added
+    apt:
+      pkg: nginx
+      state: absent
+    when: added_ppa.changed

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,5 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - ansible-role-nginx
+    - role: ansible-role-nginx
+      nginx_use_ppa: true


### PR DESCRIPTION
adds ppa:nginx to apt repositories when
nginx_use_ppa is set to true (default false)

nginx_ppa_version can be either "stable" or "development"

this will reinstall nginx if ppa was just added to ensure that the ppa
version will be installed

fixes Issue #27