### PR TITLE
Define package name and options within main context

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,10 @@
 # Used only for Debian/Ubuntu installation, as the -t option for apt.
 nginx_default_release: ""
 
+# Distros like Debian/Ubuntu ships nginx package with different flavors, e.g.
+# full, light or extras.
+nginx_package_name: "nginx"
+
 nginx_worker_processes: "1"
 nginx_worker_connections: "1024"
 
@@ -18,6 +22,12 @@ nginx_keepalive_requests: "100"
 nginx_client_max_body_size: "64m"
 
 nginx_proxy_cache_path: ""
+
+nginx_extra_conf_options: ""
+# Example extra main options, used within the main nginx's context:
+#   nginx_extra_conf_options: |
+#     env VARIABLE;
+#     include /etc/nginx/main.d/*.conf;
 
 nginx_extra_http_options: ""
 # Example extra http options, printed inside the main server http config:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,6 +4,6 @@
 
 - name: Ensure nginx is installed.
   apt:
-    pkg: nginx
+    pkg: "{{ nginx_package_name }}"
     state: installed
     default_release: "{{ nginx_default_release }}"

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -9,6 +9,10 @@ events {
     worker_connections  {{ nginx_worker_connections }};
 }
 
+{% if nginx_extra_conf_options %}
+{{ nginx_extra_conf_options }}
+{% endif %}
+
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;


### PR DESCRIPTION
    Option that allows to define options within nginx's main context.
    Option that allows to define nginx's package name.