### PR TITLE
changing Debian pidfile

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,7 +1,7 @@
 user  {{ nginx_user }};
 
 error_log  {{ nginx_error_log }};
-pid        /var/run/nginx.pid;
+pid        {{ nginx_pidfile }};
 
 worker_processes  {{ nginx_worker_processes }};
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,6 @@
 ---
 nginx_conf_path: /etc/nginx/conf.d
+nginx_pidfile: /run/nginx.pid
 nginx_vhost_path: /etc/nginx/sites-enabled
 nginx_default_vhost_path: /etc/nginx/sites-enabled/default
 __nginx_user: "www-data"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,6 @@
 ---
 nginx_conf_path: /etc/nginx/conf.d
+nginx_pidfile: /var/run/nginx.pid
 nginx_vhost_path: /etc/nginx/conf.d
 nginx_default_vhost_path: /etc/nginx/conf.d/default.conf
 __nginx_user: "nginx"


### PR DESCRIPTION
The packaged version of nginx.conf sets the pid file to /run/nginx.pid. When the pid value is changed and nginx receives the reload signal, the pid file gets removed. This causes 'service: name=nginx state=started enabled=yes' to think nginx is down on subsequent ansible runs.
See https://trac.nginx.org/nginx/ticket/796 for more info.

This PR creates a 'nginx_pidfile' role var in order to change the nginx.conf.j2 pid for Debian hosts.