### PR TITLE
Restore nginx's default search pattern for sites-enabled

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -53,6 +53,6 @@ http {
 
     include {{ nginx_conf_path }}/*.conf;
 {% if nginx_conf_path != nginx_vhost_path %}
-    include {{ nginx_vhost_path }}/*.conf;
+    include {{ nginx_vhost_path }}/*;
 {% endif %}
 }


### PR DESCRIPTION
Restore default naming scheme for nginx's `sites-enabled`.

Default names for symlinks in `sites-enabled` are plain names without `.conf` extension. Default vhost name is `default`, but currently the role does not recognize it leading to "webpage not available" error on completion.

(basically revert 50% of [restore compartability with geerlingguy-kibana](https://github.com/geerlingguy/ansible-role-nginx/commit/d209cbe89ac3f19968e7292fa678606bd17ba133) commit)