### PR TITLE
`server_tokens` is disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Extra lines to be inserted in the top-level `http` block in `nginx.conf`. The va
 
 (For Debian/Ubuntu only) Allows you to set a different repository for the installation of Nginx. As an example, if you are running Debian's wheezy release, and want to get a newer version of Nginx, you can install the `wheezy-backports` repository and set that value here, and Ansible will use that as the `-t` option while installing Nginx.
 
+`server_tokens` is disabled by default for security reasons. You can enable tokens by setting up the variable below.
+
+```
+nginx_server_tokens: "on"
+```
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ nginx_package_name: "nginx"
 nginx_worker_processes: "1"
 nginx_worker_connections: "1024"
 nginx_multi_accept: "off"
+nginx_server_tokens: "off"
 
 nginx_error_log: "/var/log/nginx/error.log warn"
 nginx_access_log: "/var/log/nginx/access.log main buffer=16k"

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -18,6 +18,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    server_tokens {{ nginx_server_tokens }};
     server_names_hash_bucket_size 64;
 
     client_max_body_size {{ nginx_client_max_body_size }};


### PR DESCRIPTION
Actually, This setting can be changed by `nginx_extra_http_options`, but I think it's better to disable by default. If not, possibly, most of the people such as me will forget it
