### PR TITLE
make the "server_name" directive optional

### DIFF
--- a/templates/vhosts.j2
+++ b/templates/vhosts.j2
@@ -1,7 +1,10 @@
 {% for vhost in nginx_vhosts %}
 server {
     listen {{ vhost.listen | default('80 default_server') }};
+
+    {% if vhost.server_name is defined %}
     server_name {{ vhost.server_name }};
+    {% endif %}
 
     {% if vhost.root is defined %}
     root {{ vhost.root }};


### PR DESCRIPTION
An nginx server block does not require a `server_name`, so no need to enforce that in this package. A use case is a "no default" setup, as recommended by the [HTML5 Boilerplate](https://html5boilerplate.com/) project:

https://github.com/h5bp/server-configs-nginx/blob/3921535db8b9123432fe11a18842989c48fe7b07/sites-available/no-default