### PR TITLE
prevent whitespace from jinja control structures from making it into templates

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -10,9 +10,9 @@ events {
     multi_accept {{ nginx_multi_accept }};
 }
 
-{% if nginx_extra_conf_options %}
+{% if nginx_extra_conf_options -%}
 {{ nginx_extra_conf_options }}
-{% endif %}
+{%- endif %}
 
 http {
     include       /etc/nginx/mime.types;
@@ -37,27 +37,28 @@ http {
 
     #gzip  on;
 
-{% if nginx_proxy_cache_path %}
+{%- if nginx_proxy_cache_path -%}
     proxy_cache_path {{ nginx_proxy_cache_path }};
 {% endif %}
 
-{% if nginx_extra_http_options %}
+{%- if nginx_extra_http_options -%}
     {{ nginx_extra_http_options }}
 {% endif %}
 
-{% for upstream in nginx_upstreams %}
+{%- for upstream in nginx_upstreams -%}
     upstream {{ upstream.name }} {
-{% if upstream.strategy is defined %}
+{%- if upstream.strategy is defined -%}
         {{ upstream.strategy }};
 {% endif %}
-{% for server in upstream.servers %}
+{%- for server in upstream.servers -%}
         server {{ server }};
 {% endfor %}
     }
 {% endfor %}
 
     include {{ nginx_conf_path }}/*.conf;
-{% if nginx_conf_path != nginx_vhost_path %}
+{%- if nginx_conf_path != nginx_vhost_path -%}
     include {{ nginx_vhost_path }}/*;
 {% endif %}
+
 }

--- a/templates/vhosts.j2
+++ b/templates/vhosts.j2
@@ -1,30 +1,36 @@
-{% for vhost in nginx_vhosts %}
+{% for vhost in nginx_vhosts -%}
 server {
+
     listen {{ vhost.listen | default('80 default_server') }};
     server_name {{ vhost.server_name }};
 
-    {% if vhost.root is defined %}
+    {%- if vhost.root is defined -%}
     root {{ vhost.root }};
     {% endif %}
 
-    index {{ vhost.index | default('index.html index.htm') }};
+    {%- if vhost.index is defined -%}
+    index {{ vhost.index }};
+    {% endif %}
 
-    {% if vhost.error_page is defined %}
+    {%- if vhost.error_page is defined -%}
     error_page {{ vhost.error_page }};
     {% endif %}
-    {% if vhost.access_log is defined %}
+
+    {%- if vhost.access_log is defined -%}
     access_log {{ vhost.access_log }};
     {% endif %}
-    {% if vhost.error_log is defined %}
+
+    {%- if vhost.error_log is defined -%}
     error_log {{ vhost.error_log }} error;
     {% endif %}
 
-    {% if vhost.return is defined %}
+    {%- if vhost.return is defined -%}
     return {{ vhost.return }};
     {% endif %}
 
-    {% if vhost.extra_parameters is defined %}
+    {%- if vhost.extra_parameters is defined -%}
     {{ vhost.extra_parameters }}
     {% endif %}
+
 }
 {% endfor %}


### PR DESCRIPTION
By using Jinja2's [whitespace control features](http://jinja.pocoo.org/docs/dev/templates/#whitespace-control), we can make the generated nginx templates much more pleasant to read. For example:

### Before:

```
server {
    listen 80 default_server;





        return 444;

    }
server {
    listen 80;

        server_name example.com;




        return 301 $scheme://www.example.com$request_uri;

    }
server {
    listen 80;

        server_name www.example.com;

        root /var/www/example.com/public;

        index index.html;



    }
```

### After:

```
server {

    listen 80 default_server;

    return 444;

}
server {

    listen 80;

    server_name example.com;
    return 301 $scheme://www.example.com$request_uri;

}
server {

    listen 80;

    server_name www.example.com;
    root /var/www/example.com/public;
    index index.html;

}
```