### PR TITLE
enable no_index

### DIFF
--- a/templates/vhosts.j2
+++ b/templates/vhosts.j2
@@ -7,7 +7,9 @@ server {
     root {{ vhost.root }};
     {% endif %}
 
+    {% if vhost.no_index is defined and not vhost.no_index %}
     index {{ vhost.index | default('index.html index.htm') }};
+    {% endif %}
 
     {% if vhost.error_page is defined %}
     error_page {{ vhost.error_page }};


### PR DESCRIPTION
example vhost where this would be useful:

```
- listen: 80
  server_name: example.com
  no_index: true
  extra_parameters: |
    location / {
      proxy_pass http://localhost:8000;
    }
```
