### PR TITLE
Create the Nginx vhost path directory

### DIFF
--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -7,6 +7,13 @@
   notify:
     - reload nginx
 
+- name: Create nginx_vhost_path directory.
+  file:
+    path: "{{ nginx_vhost_path }}"
+    state: directory
+  notify:
+    - reload nginx
+
 - name: Add managed vhost config file (if any vhosts are configured).
   template:
     src: vhosts.j2


### PR DESCRIPTION
In particular, the `/usr/local/etc/nginx/sites-enabled` directory does not exist on a fresh install of Nginx on FreeBSD, and the template task doesn't ensure it will.