### PR TITLE
Add nginx_vhosts_filename variable to allow multiple managed files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,7 @@ nginx_extra_http_options: ""
 #      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
 #      proxy_set_header   Host $http_host;
 
+nginx_vhosts_filename: "vhosts.conf"
 nginx_remove_default_vhost: false
 nginx_vhosts: []
 # Example vhost below, showing all available options:

--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -10,7 +10,7 @@
 - name: Add managed vhost config file (if any vhosts are configured).
   template:
     src: vhosts.j2
-    dest: "{{ nginx_vhost_path }}/vhosts.conf"
+    dest: "{{ nginx_vhost_path }}/{{ nginx_vhosts_filename }}"
     mode: 0644
   when: nginx_vhosts|length > 0
   notify:
@@ -18,9 +18,8 @@
 
 - name: Remove managed vhost config file (if no vhosts are configured).
   file:
-    path: "{{ nginx_vhost_path }}/vhosts.conf"
+    path: "{{ nginx_vhost_path }}/{{ nginx_vhosts_filename }}"
     state: absent
   when: nginx_vhosts|length == 0
   notify:
     - reload nginx
-


### PR DESCRIPTION
It allows to configure vhosts filename with `nginx_vhosts_filename` variable. It defaults "vhosts.conf". (See #61).