### PR TITLE
Restart instead of reload after remove default.

### DIFF
--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -4,7 +4,7 @@
     path: "{{ nginx_default_vhost_path }}"
     state: absent
   when: nginx_remove_default_vhost
-  notify: reload nginx
+  notify: restart nginx
 
 - name: Ensure nginx_vhost_path exists.
   file:


### PR DESCRIPTION
My system : Debian.
After the installation of Nginx, the service is up and running. So, by default, the process listen to (and lock)  0.0.0.0:80.

If you set `nginx_remove_default_vhost: true`, reloading is not enough to release the lock. The ansible role has to restart the nginx.

Let me expose a use case, on the same server, the nginx has to listen to 127.0.0.1:80 and the Haproxy to <eth_ip>:80. A lock on 0.0.0.0:80 causes a fail of the playbook apply.
