### PR TITLE
format nginx_extra_http_options with indent

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -42,7 +42,7 @@ http {
 {% endif %}
 
 {% if nginx_extra_http_options %}
-    {{ nginx_extra_http_options }}
+    {{ nginx_extra_http_options|indent(4, False) }}
 {% endif %}
 
 {% for upstream in nginx_upstreams %}


### PR DESCRIPTION
http section in nginx.conf is indented by default. To increase
readability format the variable nginx_extra_http_options with
the same indent for multiline string blocks. Therefore indent
needs not to be done in yaml.