### PR TITLE
Parametrize log_format

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,3 +68,7 @@ nginx_upstreams: []
 #     "srv2.example.com weight=3",
 #     "srv3.example.com"
 #   }
+nginx_log_format: |
+  '$remote_addr - $remote_user [$time_local] "$request" '
+  '$status $body_bytes_sent "$http_referer" '
+  '"$http_user_agent" "$http_x_forwarded_for"'

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -22,9 +22,7 @@ http {
 
     client_max_body_size {{ nginx_client_max_body_size }};
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format  main  {{ nginx_log_format|indent(23) }};
 
     access_log  {{ nginx_access_log }};
 


### PR DESCRIPTION
`geerlingguy.nginx` prevents `log_format` customization. nginx triggers an emergency error on twice declaration of log_format. So we should allow to customize this. What do you think of this ?