### PR TITLE
adding yum repo flag for Redhat

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 # Used only for Debian/Ubuntu installation, as the -t option for apt.
 nginx_default_release: ""
 
+# Used only for Redhat installation, enables source Nginx repo.
+nginx_yum_repo_enabled: true
+
 # Use the official Nginx PPA for Ubuntu, and the version to use if so.
 nginx_ppa_use: false
 nginx_ppa_version: stable

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -6,9 +6,9 @@
     owner: root
     group: root
     mode: 0644
+  when: nginx_yum_repo_enabled
 
 - name: Ensure nginx is installed.
   yum:
     name: "{{ nginx_package_name }}"
     state: installed
-    enablerepo: nginx


### PR DESCRIPTION
In environments where RHEL uses Satellite or production servers can't
reach out to the internet, and the Yum repo is not wanted. This commit
adds a flag to disable the functionality. It also removes the
enablerepo: nginx line from the package since a) it's redundant and b)
working around it overly complicates  the situation.