### PR TITLE
Moved the nginx_extra_conf_options above the events block to accommodate load_module.

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -5,14 +5,15 @@ pid        {{ nginx_pidfile }};
 
 worker_processes  {{ nginx_worker_processes }};
 
+{% if nginx_extra_conf_options %}
+{{ nginx_extra_conf_options }}
+{% endif %}
+
 events {
     worker_connections  {{ nginx_worker_connections }};
     multi_accept {{ nginx_multi_accept }};
 }
 
-{% if nginx_extra_conf_options %}
-{{ nginx_extra_conf_options }}
-{% endif %}
 
 http {
     include       {{ nginx_mime_file_path }};


### PR DESCRIPTION
So I ended up doing this because (at least with the jessie-backport) the `nginx-extras` modules are all compiled in as dynamic modules, and require you to call `load_module` in order to bring them in and use their features. 

As it turns out, `load_module` cannot be used below the events block (and probably any block for that matter.) So here I am.

I had thought about creating a new variable such as `nginx_dynamic_modules: []`, but `load_module` was only added since 1.9.11 (http://nginx.org/en/docs/ngx_core_module.html#load_module), and I didn't want to add something that wasn't backwards compatible.

Thanks for the useful Ansible modules, by the way!