### PR TITLE
Added load_module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Available variables are listed below, along with default values (see `defaults/m
 
     nginx_vhosts: []
 
+A list of dynamic modules to load, the implementation assumes you will
+provide the correct path of the path as opposed to just the module name; defaults to `[]`.
+
+    nginx_dynamic_modules:
+      - modules/ngx_http_geoip_module.so
+
 A list of vhost definitions (server blocks) for Nginx virtual hosts. If left empty, you will need to supply your own virtual host configuration. See the commented example in `defaults/main.yml` for available server options. If you have a large number of customizations required for your server definition(s), you're likely better off managing the vhost configuration file yourself, leaving this variable set to `[]`.
 
     nginx_vhosts:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,9 @@ nginx_ppa_version: stable
 # The name of the nginx apt/yum package to install.
 nginx_package_name: "nginx"
 
+# List of dynamic modules to load
+nginx_dynamic_modules: []
+
 nginx_worker_processes: "{{ ansible_processor_vcpus | default(ansible_processor_count) }}"
 nginx_worker_connections: "1024"
 nginx_multi_accept: "off"

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -3,6 +3,10 @@ user  {{ nginx_user }};
 error_log  {{ nginx_error_log }};
 pid        {{ nginx_pidfile }};
 
+{% for module in nginx_dynamic_modules %}
+load_module "{{ module }}";
+{% endfor %}
+
 worker_processes  {{ nginx_worker_processes }};
 
 events {


### PR DESCRIPTION
NGINX is particular about config order of `load_module` so the existing
variable `nginx_extra_conf_options` was not sufficient since it was
below the event block.