### PR TITLE
Followup #91: Add `filename` option `nginx_vhosts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A list of vhost definitions (server blocks) for Nginx virtual hosts. Each entry 
         error_log: ""
         state: "present"
         template: "{{ nginx_vhost_template }}"
-        vhost_filename: "example.com.conf"
+        filename: "example.com.conf"
         extra_parameters: |
           location ~ \.php$ {
               fastcgi_split_path_info ^(.+\.php)(/.+)$;
@@ -50,11 +50,11 @@ Please take note of the indentation in the above block. The first line should be
       - listen: "80"
         server_name: "example.com www.example.com"
         return "301 https://example.com$request_uri;"
-        vhost_filename: "example.com.80.conf"
+        filename: "example.com.80.conf"
 
 An example of a secondary vhost which will redirect to the one shown above.
 
-*Note: The `vhost_filename` defaults to the first domain in `server_name`, if you have two vhosts with the same domain, eg. a redirect, you need to manually set the `vhost_filename` so the second one doesn't override the first one*
+*Note: The `filename` defaults to the first domain in `server_name`, if you have two vhosts with the same domain, eg. a redirect, you need to manually set the `filename` so the second one doesn't override the first one*
 
     nginx_remove_default_vhost: false
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Available variables are listed below, along with default values (see `defaults/m
 A list of vhost definitions (server blocks) for Nginx virtual hosts. Each entry will create a separate config file named by `server_name`. If left empty, you will need to supply your own virtual host configuration. See the commented example in `defaults/main.yml` for available server options. If you have a large number of customizations required for your server definition(s), you're likely better off managing the vhost configuration file yourself, leaving this variable set to `[]`.
 
     nginx_vhosts:
-      - listen: "80 default_server"
+      - listen: "443 ssl http2"
         server_name: "example.com"
         server_name_redirect: "www.example.com"
         root: "/var/www/example.com"
@@ -38,10 +38,23 @@ A list of vhost definitions (server blocks) for Nginx virtual hosts. Each entry 
               fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
               include fastcgi_params;
           }
+          ssl_certificate     /etc/ssl/certs/ssl-cert-snakeoil.pem;
+          ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+          ssl_protocols       TLSv1.1 TLSv1.2;
+          ssl_ciphers         HIGH:!aNULL:!MD5;
 
 An example of a fully-populated nginx_vhosts entry, using a `|` to declare a block of syntax for the `extra_parameters`.
 
 Please take note of the indentation in the above block. The first line should be a normal 2-space indent. All other lines should be indented normally relative to that line. In the generated file, the entire block will be 4-space indented. This style will ensure the config file is indented correctly.
+
+      - listen: "80"
+        server_name: "example.com www.example.com"
+        return "301 https://example.com$request_uri;"
+        vhost_filename: "example.com.80.conf"
+
+An example of a secondary vhost which will redirect to the one shown above.
+
+*Note: The `vhost_filename` defaults to the first domain in `server_name`, if you have two vhosts with the same domain, eg. a redirect, you need to manually set the `vhost_filename` so the second one doesn't override the first one*
 
     nginx_remove_default_vhost: false
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A list of vhost definitions (server blocks) for Nginx virtual hosts. Each entry 
     nginx_vhosts:
       - listen: "80 default_server"
         server_name: "example.com"
+        server_name_redirect: "www.example.com"
         root: "/var/www/example.com"
         index: "index.php index.html index.htm"
         error_page: ""

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A list of vhost definitions (server blocks) for Nginx virtual hosts. Each entry 
         error_log: ""
         state: "present"
         template: "{{ nginx_vhost_template }}"
+        vhost_filename: "example.com.conf"
         extra_parameters: |
           location ~ \.php$ {
               fastcgi_split_path_info ^(.+\.php)(/.+)$;

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,12 +57,12 @@ nginx_vhosts: []
 # Example vhost below, showing all available options:
 # - listen: "80" # default: "80"
 #   server_name: "example.com" # default: N/A
-#   server_name_redirect: "www.example.com" # default: N/A
 #   root: "/var/www/example.com" # default: N/A
 #   index: "index.html index.htm" # default: "index.html index.htm"
 #   vhost_filename: "example.com.conf" # Can be used to set the filename of the vhost file.
 #
 #   # Properties that are only added if defined:
+#   server_name_redirect: "www.example.com" # default: N/A
 #   error_page: ""
 #   access_log: ""
 #   error_log: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,7 @@ nginx_vhosts: []
 #   server_name_redirect: "www.example.com" # default: N/A
 #   root: "/var/www/example.com" # default: N/A
 #   index: "index.html index.htm" # default: "index.html index.htm"
+#   vhost_filename: "example.com.conf" # Can be used to set the filename of the vhost file.
 #
 #   # Properties that are only added if defined:
 #   error_page: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,7 +59,7 @@ nginx_vhosts: []
 #   server_name: "example.com" # default: N/A
 #   root: "/var/www/example.com" # default: N/A
 #   index: "index.html index.htm" # default: "index.html index.htm"
-#   vhost_filename: "example.com.conf" # Can be used to set the filename of the vhost file.
+#   filename: "example.com.conf" # Can be used to set the filename of the vhost file.
 #
 #   # Properties that are only added if defined:
 #   server_name_redirect: "www.example.com" # default: N/A

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,8 +55,9 @@ nginx_extra_http_options: ""
 nginx_remove_default_vhost: false
 nginx_vhosts: []
 # Example vhost below, showing all available options:
-# - listen: "80 default_server" # default: "80 default_server"
+# - listen: "80" # default: "80"
 #   server_name: "example.com" # default: N/A
+#   server_name_redirect: "www.example.com" # default: N/A
 #   root: "/var/www/example.com" # default: N/A
 #   index: "index.html index.htm" # default: "index.html index.htm"
 #

--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -15,7 +15,7 @@
 - name: Add managed vhost config files.
   template:
     src: "{{ item.template|default(nginx_vhost_template) }}"
-    dest: "{{ nginx_vhost_path }}/{{ item.vhost_filename|default(item.server_name.split(' ')[0] ~ '.conf') }}"
+    dest: "{{ nginx_vhost_path }}/{{ item.filename|default(item.server_name.split(' ')[0] ~ '.conf') }}"
     force: yes
     owner: root
     group: root
@@ -26,7 +26,7 @@
 
 - name: Remove managed vhost config files.
   file:
-    path: "{{ nginx_vhost_path }}/{{ item.vhost_filename|default(item.server_name.split(' ')[0] ~ '.conf') }}"
+    path: "{{ nginx_vhost_path }}/{{ item.filename|default(item.server_name.split(' ')[0] ~ '.conf') }}"
     state: absent
   when: item.state|default('present') == 'absent'
   with_items: "{{ nginx_vhosts }}"

--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -15,7 +15,7 @@
 - name: Add managed vhost config files.
   template:
     src: "{{ item.template|default(nginx_vhost_template) }}"
-    dest: "{{ nginx_vhost_path }}/{{ item.server_name.split(' ')[0] }}.conf"
+    dest: "{{ nginx_vhost_path }}/{{ item.vhost_filename|default(item.server_name.split(' ')[0] ~ '.conf') }}"
     force: yes
     owner: root
     group: root
@@ -26,7 +26,7 @@
 
 - name: Remove managed vhost config files.
   file:
-    path: "{{ nginx_vhost_path }}/{{ item.server_name.split(' ')[0] }}.conf"
+    path: "{{ nginx_vhost_path }}/{{ item.vhost_filename|default(item.server_name.split(' ')[0] ~ '.conf') }}"
     state: absent
   when: item.state|default('present') == 'absent'
   with_items: "{{ nginx_vhosts }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,11 +10,12 @@
 
   pre_tasks:
     - name: Update apt cache.
-      apt: update_cache=yes cache_valid_time=86400
+      apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
+      changed_when: false
 
     - name: Install dependencies.
-      package: name=curl
+      package: name=curl state=present
 
   roles:
     - role_under_test


### PR DESCRIPTION
One solution of how we could fix the problem brought forward here https://github.com/geerlingguy/ansible-role-nginx/pull/91#issuecomment-305544257. Currently it's not possible to create a redirect from http -> https as the domain names would be identical and therefore the second vhost file would overwrite the first one.

I also improved the README example so it shows a more advanced, but very common scenario where you want to redirect all http traffic to https, as well as redirect www.example.com to example.com.

Any better ideas?