### PR TITLE
Load modules before events directive

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -7,16 +7,16 @@ pid        {{ nginx_pidfile }};
 worker_processes  {{ nginx_worker_processes }};
 {% endblock %}
 
+{% if nginx_extra_conf_options %}
+{{ nginx_extra_conf_options }}
+{% endif %}
+
 {% block events %}
 events {
     worker_connections  {{ nginx_worker_connections }};
     multi_accept {{ nginx_multi_accept }};
 }
 {% endblock %}
-
-{% if nginx_extra_conf_options %}
-{{ nginx_extra_conf_options }}
-{% endif %}
 
 http {
     {% block http_begin %}{% endblock %}


### PR DESCRIPTION
In Nginx 1.12.x (latest stable version) you will have a config error
if you try to load modules before the events directive. With this
change we avoid this problem.