### PR TITLE
Allow overriding of nginx_vhost_path and nginx_default_vhost_path.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,16 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
+- name: Define nginx_vhost_path.
+  set_fact:
+    nginx_vhost_path: "{{ __nginx_vhost_path }}"
+  when: nginx_vhost_path is not defined
+
+- name: Define nginx_default_vhost_path.
+  set_fact:
+    nginx_default_vhost_path: "{{ __nginx_default_vhost_path }}"
+  when: nginx_default_vhost_path is not defined
+
 - name: Define nginx_user.
   set_fact:
     nginx_user: "{{ __nginx_user }}"

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -4,6 +4,6 @@ nginx_conf_path: /etc/nginx/conf.d
 nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
 nginx_pidfile: /run/nginx.pid
-nginx_vhost_path: /etc/nginx/sites-enabled
-nginx_default_vhost_path: /etc/nginx/sites-enabled/default
+__nginx_vhost_path: /etc/nginx/sites-enabled
+__nginx_default_vhost_path: /etc/nginx/sites-enabled/default
 __nginx_user: "http"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,6 +4,6 @@ nginx_conf_path: /etc/nginx/conf.d
 nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
 nginx_pidfile: /run/nginx.pid
-nginx_vhost_path: /etc/nginx/sites-enabled
-nginx_default_vhost_path: /etc/nginx/sites-enabled/default
+__nginx_vhost_path: /etc/nginx/sites-enabled
+__nginx_default_vhost_path: /etc/nginx/sites-enabled/default
 __nginx_user: "www-data"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -4,6 +4,6 @@ nginx_conf_path: /usr/local/etc/nginx/conf.d
 nginx_conf_file_path: /usr/local/etc/nginx/nginx.conf
 nginx_mime_file_path: /usr/local/etc/nginx/mime.types
 nginx_pidfile: /var/run/nginx.pid
-nginx_vhost_path: /usr/local/etc/nginx/sites-enabled
-nginx_default_vhost_path: /usr/local/etc/nginx/sites-enabled/default
+__nginx_vhost_path: /usr/local/etc/nginx/sites-enabled
+__nginx_default_vhost_path: /usr/local/etc/nginx/sites-enabled/default
 __nginx_user: "www"

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -4,7 +4,7 @@ nginx_conf_path: /etc/nginx/conf.d
 nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
 nginx_pidfile: /var/run/nginx.pid
-nginx_vhost_path: /etc/nginx/sites-enabled
-nginx_default_vhost_path: /etc/nginx/sites-enabled/default
+__nginx_vhost_path: /etc/nginx/sites-enabled
+__nginx_default_vhost_path: /etc/nginx/sites-enabled/default
 nginx_package_name: "nginx--"
 __nginx_user: "www"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,6 +4,6 @@ nginx_conf_path: /etc/nginx/conf.d
 nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
 nginx_pidfile: /var/run/nginx.pid
-nginx_vhost_path: /etc/nginx/conf.d
-nginx_default_vhost_path: /etc/nginx/conf.d/default.conf
+__nginx_vhost_path: /etc/nginx/conf.d
+__nginx_default_vhost_path: /etc/nginx/conf.d/default.conf
 __nginx_user: "nginx"


### PR DESCRIPTION
Now overridable:
`nginx_vhost_path` and `nginx_default_vhost_path`.

Defaults still the same for all OSes.

@geerlingguy Not sure what to write in the readme to update that too. Any ideas?

Also, I guess it would be possible to make the same changes for all other location variables, but it's up to you 👍 

Fixes #114 