### PR TITLE
Fix check mode failure

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: restart nginx
   service: name=nginx state=restarted
+  when: not ansible_check_mode
 
 - name: validate nginx configuration
   command: nginx -t -c /etc/nginx/nginx.conf
@@ -8,3 +9,4 @@
 
 - name: reload nginx
   service: name=nginx state=reloaded
+  when: not ansible_check_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,3 +37,4 @@
 
 - name: Ensure nginx is started and enabled to start at boot.
   service: name=nginx state=started enabled=yes
+  when: not ansible_check_mode


### PR DESCRIPTION
If using this role for the first time in check mode, the role bombs out and fails because the nginx service doesn't exist (which make sense since it hasn't installed nginx yet due to check mode).

This change lets check mode keep running.