### PR TITLE
fix chgrp failed - FreeBSD and OpenBSD

### DIFF
--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -18,7 +18,7 @@
     dest: "{{ nginx_vhost_path }}/{{ item.filename|default(item.server_name.split(' ')[0] ~ '.conf') }}"
     force: yes
     owner: root
-    group: root
+    group: "{{ root_group }}"
     mode: 0644
   when: item.state|default('present') != 'absent'
   with_items: "{{ nginx_vhosts }}"


### PR DESCRIPTION
This change fix chgrp error on FreeBSD and OpenBSD.
root group does not exist on these *BSD systems. Instead must use wheel group.

error message:
chgrp failed: failed to look up group root