### PR TITLE
 Allow other service names besides 'nginx', option to not include OS variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,9 @@ nginx_ppa_version: stable
 # The name of the nginx package to install.
 nginx_package_name: "nginx"
 
+# If the name of the service is not nginx, it can be customized
+nginx_service_name: nginx
+
 nginx_conf_template: "nginx.conf.j2"
 nginx_vhost_template: "vhost.j2"
 
@@ -84,3 +87,6 @@ nginx_log_format: |
   '$remote_addr - $remote_user [$time_local] "$request" '
   '$status $body_bytes_sent "$http_referer" '
   '"$http_user_agent" "$http_x_forwarded_for"'
+
+# If one does not desire to include the OS-specific variables (vars/{{ ansible_os_family }}.yaml)
+nginx_include_os_vars: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: restart nginx
-  service: name=nginx state=restarted
+  service: name={{ nginx_service_name }} state=restarted
 
 - name: validate nginx configuration
-  command: nginx -t -c /etc/nginx/nginx.conf
+  command: nginx -t -c {{ nginx_conf_file_path }}
   changed_when: False
 
 - name: reload nginx
-  service: name=nginx state=reloaded
+  service: name={{ nginx_service_name }} state=reloaded

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 # Variable setup.
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
+  when: nginx_include_os_vars
 
 - name: Define nginx_user.
   set_fact:
@@ -42,4 +43,4 @@
     - reload nginx
 
 - name: Ensure nginx is started and enabled to start at boot.
-  service: name=nginx state=started enabled=yes
+  service: name={{ nginx_service_name }} state=started enabled=yes


### PR DESCRIPTION
This PR includes two parts:
# Allow custom service names
The name of the service shouldn't be hardcoded to `nginx`, as it disallows any customization. I added a default of `nginx` but allow over-writing it with a variable called `nginx_service_name`.

# Give the option to not include OS variables
According to the [Variable Precedence](http://docs.ansible.com/ansible/latest/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) in the Ansible documentation, variables that are included with `include_vars` are almost the highest priority possible. When setting variables myself, then using the role, my variables get overwritten. Adding the ability to not include the OS variables allows greater flexibility in setting things like custom nginx.conf paths, and pidfiles. By setting `nginx_include_os_vars` to False, that stage is skipped over.

Take for example trying to change the nginx.conf path to use openresty instead:
```yaml
- hosts: 'webservers'
  roles:
    - geerlingguy.nginx
  vars:
    nginx_conf_file_path: /usr/local/openresty/nginx/conf/nginx.conf
...
```
When Ansible gets to `Include OS-specific variables` in `main.yaml` my variable for `nginx_conf_path` is overwritten, and the Debian (in my case) version takes precedence. If there is another way to ensure my variable is chosen without passing `-e nginx_conf_file_path=/usr/local/openresty/nginx/conf/nginx.conf` on the command line, I'd love to hear it, as I'm new to using Ansible roles from the Galaxy.

Thank you.