### PR TITLE
Allow custom extra 'listen' directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ An example of a secondary vhost which will redirect to the one shown above.
 
 *Note: The `filename` defaults to the first domain in `server_name`, if you have two vhosts with the same domain, eg. a redirect, you need to manually set the `filename` so the second one doesn't override the first one*
 
+    nginx_vhosts:
+      - listen:
+          - "80"
+          - "443 ssl http2"
+        server_name: "example.com"
+        server_name_redirect: "www.example.com"
+        filename: "example.com.conf"
+        extra_parameters: |
+          ssl_certificate     /etc/ssl/certs/ssl-cert-snakeoil.pem;
+          ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+
+An example of double listen for the same `server_name`
+
     nginx_remove_default_vhost: false
 
 Whether to remove the 'default' virtualhost configuration supplied by Nginx. Useful if you want the base `/` URL to be directed at one of your own virtual hosts configured in a separate .conf file.

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,5 +6,5 @@
 - name: Ensure nginx is installed.
   apt:
     name: "{{ nginx_package_name }}"
-    state: installed
+    state: present
     default_release: "{{ nginx_default_release }}"

--- a/templates/vhost.j2
+++ b/templates/vhost.j2
@@ -1,7 +1,15 @@
 {% block server_redirect %}
 {% if item.server_name_redirect is defined %}
 server {
-    listen       {{ item.listen | default('80') }};
+
+{% if item.listen is defined and item.listen is not string %}
+    {% for listen in item.listen -%}
+        listen {{ listen }};
+    {% endfor %}
+{% else %}
+    listen {{ item.listen | default('80') }};
+{% endif %}
+
     server_name  {{ item.server_name_redirect }};
     return       301 $scheme://{{ item.server_name.split(' ')[0] }}$request_uri;
 }
@@ -12,7 +20,14 @@ server {
     {% block server_begin %}{% endblock %}
 
     {% block server_basic -%}
+
+{% if item.listen is defined and item.listen is not string -%}
+    {% for listen in item.listen -%}
+        listen {{ listen }};
+    {% endfor %}
+{% else -%}
     listen {{ item.listen | default('80') }};
+{% endif %}
 
 {% if item.server_name is defined %}
     server_name {{ item.server_name }};


### PR DESCRIPTION
Enables multiple listen directives for the same `server_name`

    ---
    nginx_vhosts:
      - listen:
          - "443 ssl http2"
          - "80"
        server_name: "example.com"
        server_name_redirect: "www.example.com"
        filename: "example.com.conf"
        extra_parameters: |
          ssl_certificate     /etc/ssl/certs/ssl-cert-snakeoil.pem;
          ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;

Example output:

    server {

        listen 443 ssl http2;
        listen 80;

        server_name  www.example.com;
        return       301 $scheme://example.com$request_uri;
    }

    server {

        listen 443 ssl http2;
        listen 80;

        server_name example.com;


        index index.html index.htm;




        ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
        ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;

    }

Could be an alternative to #86