### PR TITLE
Using become to restart services in handlers.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,10 +1,13 @@
 ---
 - name: restart nginx
   service: name=nginx state=restarted
+  become: true
 
 - name: validate nginx configuration
   command: nginx -t -c /etc/nginx/nginx.conf
   changed_when: False
+  become: true
 
 - name: reload nginx
   service: name=nginx state=reloaded
+  become: true


### PR DESCRIPTION
I just tried to use the 'include_role' task on this role, and got this error:

> Unable to restart service nginx: Failed to restart nginx.service: The name org.freedesktop.PolicyKit1 was not provided by any .service files

When I added the `become: true` directive to each of those tasks it started working again. Same happened with the geerlingguy.php role btw. I can create a pull request for that one as well if you want.
