### PR TITLE
fix of issue #143

### DIFF
--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -3,6 +3,8 @@ root_group: wheel
 nginx_conf_path: /etc/nginx/conf.d
 nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
+nginx_error_log: /var/www/logs/error.log
+nginx_access_log: /var/www/logs/access.log
 nginx_pidfile: /var/run/nginx.pid
 nginx_vhost_path: /etc/nginx/sites-enabled
 nginx_default_vhost_path: /etc/nginx/sites-enabled/default


### PR DESCRIPTION
Matching the logfiles location with the content of nginx(8) on OpenBSD. Although nginx has been moved to the ports on that OS, and doesn't have an official manpage anymore, the manpage of the port still specifies the location in this commit.