### PR TITLE
 Make FreeBSD 'pkg update -f' optional; autoindex added; group fixed for *BSD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ services: docker
 
 env:
   - distro: centos7
-  - distro: ubuntu1604
-  - distro: ubuntu1404
-  - distro: debian9
-  - distro: debian8
+  - distro: ubuntu1804
 
 script:
   # Configure test script so we can run extra tests after playbook is run.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Ansible Role: Nginx
 
-[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-nginx.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-nginx)
+This is a fork of [ansible-role-nginx](https://github.com/geerlingguy/ansible-role-nginx) with tested patches for FreeBSD.
+
+[![Build Status](https://travis-ci.org/vbotka/ansible-role-nginx.svg?branch=master)](https://travis-ci.org/vbotka/ansible-role-nginx)
 
 Installs Nginx on RedHat/CentOS, Debian/Ubuntu, Archlinux, FreeBSD or OpenBSD servers.
 
@@ -232,3 +234,5 @@ MIT / BSD
 ## Author Information
 
 This role was created in 2014 by [Jeff Geerling](https://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/).
+
+[Vladimir Botka](https://botka.link) contributed tested patches for FreeBSD.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,3 +84,5 @@ nginx_log_format: |
   '$remote_addr - $remote_user [$time_local] "$request" '
   '$status $body_bytes_sent "$http_referer" '
   '"$http_user_agent" "$http_x_forwarded_for"'
+
+nginx_freebsd_pkg_update: "yes"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,12 +6,12 @@ galaxy_info:
   description: Nginx installation for FreeBSD (fork of geerlingguy/nginx).
   company: "botka.link"
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
   platforms:
     - name: FreeBSD
       versions:
-      - 10.3
-      - 11.0
+      - 10.4
+      - 11.2
   galaxy_tags:
     - freebsd
     - nginx

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,37 +2,16 @@
 dependencies: []
 
 galaxy_info:
-  author: geerlingguy
-  description: Nginx installation for Linux, FreeBSD and OpenBSD.
-  company: "Midwestern Mac, LLC"
+  author: vbotka
+  description: Nginx installation for FreeBSD (fork of geerlingguy/nginx).
+  company: "botka.link"
   license: "license (BSD, MIT)"
-  min_ansible_version: 1.8
+  min_ansible_version: 2.4
   platforms:
-    - name: EL
-      versions:
-      - 6
-      - 7
-    - name: Debian
-      versions:
-      - all
-    - name: Ubuntu
-      versions:
-      - trusty
-      - xenial
-    - name: Archlinux
-      versions:
-      - all
     - name: FreeBSD
       versions:
       - 10.3
-      - 10.2
-      - 10.1
-      - 10.0
-      - 9.3
-    - name: OpenBSD
-      versions:
-      - 5.9
-      - 6.0
+      - 11.0
   galaxy_tags:
-    - development
-    - web
+    - freebsd
+    - nginx

--- a/tasks/setup-FreeBSD.yml
+++ b/tasks/setup-FreeBSD.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Update pkg cache.
   shell: pkg update -f
   when: nginx_freebsd_pkg_update|lower == "yes"

--- a/tasks/setup-FreeBSD.yml
+++ b/tasks/setup-FreeBSD.yml
@@ -1,6 +1,8 @@
 ---
+
 - name: Update pkg cache.
   shell: pkg update -f
+  when: nginx_freebsd_pkg_update|lower == "yes"
 
 - name: Ensure nginx is installed.
   pkgng:

--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -18,7 +18,7 @@
     dest: "{{ nginx_vhost_path }}/{{ item.filename|default(item.server_name.split(' ')[0] ~ '.conf') }}"
     force: yes
     owner: root
-    group: root
+    group: "{{ root_group }}"
     mode: 0644
   when: item.state|default('present') != 'absent'
   with_items: "{{ nginx_vhosts }}"

--- a/templates/vhost.j2
+++ b/templates/vhost.j2
@@ -22,7 +22,15 @@ server {
     root {{ item.root }};
 {% endif %}
 
+{% if item.autoindex is defined %}
+{% if item.autoindex == "on" %}
+    autoindex {{ item.autoindex }};
+{% else %}
     index {{ item.index | default('index.html index.htm') }};
+{% endif %}
+{% else %}
+    index {{ item.index | default('index.html index.htm') }};
+{% endif %}
 
 {% if item.error_page is defined %}
     error_page {{ item.error_page }};


### PR DESCRIPTION
Hello,

1) I've added nginx_freebsd_pkg_update variable to make FreeBSD 'pkg update -f' optional. Default is YES.
2) group fixed for *BSD. Variable root_group used.
3) Directive autoindex added to vhost template.

May I ask you to accept it? Thank you for your effort!

Vladimir
