### PR TITLE
Add 'nginx_fastcgi_cache_path' configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ This value determines the largest file upload possible, as uploads are passed th
 
 If you have many server names, or have very long server names, you might get an Nginx error on startup requiring this value to be increased.
 
+    nginx_fastcgi_cache_path: ""
+
+Set as the `fastcgi_cache_path` directive in the `nginx.conf` file. By default, this will not be configured (if left as an empty string), but if you wish to use Nginx with a fastcgi cache, you can set this to a valid value (e.g. `"/var/cache/nginx-fastcgi-cache keys_zone=fastcgi-cache:32m"`) to use Nginx's fastcgi cache (further fastcgi configuration can be done in individual server configurations).
+
     nginx_proxy_cache_path: ""
 
 Set as the `proxy_cache_path` directive in the `nginx.conf` file. By default, this will not be configured (if left as an empty string), but if you wish to use Nginx as a reverse proxy, you can set this to a valid value (e.g. `"/var/cache/nginx keys_zone=cache:32m"`) to use Nginx's cache (further proxy configuration can be done in individual server configurations).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,8 @@ nginx_client_max_body_size: "64m"
 
 nginx_server_names_hash_bucket_size: "64"
 
+nginx_fastcgi_cache_path: ""
+
 nginx_proxy_cache_path: ""
 
 nginx_extra_conf_options: ""

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -41,6 +41,9 @@ http {
     keepalive_requests {{ nginx_keepalive_requests }};
 
     server_tokens {{ nginx_server_tokens }};
+{% if nginx_fastcgi_cache_path %}
+    fastcgi_cache_path {{ nginx_fastcgi_cache_path }};
+{% endif %}
 {% if nginx_proxy_cache_path %}
     proxy_cache_path {{ nginx_proxy_cache_path }};
 {% endif %}


### PR DESCRIPTION
This is very similar to the nginx_proxy_cache_path, but instead provides a cache for fastcgi caching.