### PR TITLE
Add ability to specify repo for Centos/RHEL installs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ nginx_yum_repo_enabled: true
 nginx_ppa_use: false
 nginx_ppa_version: stable
 
+# Use an alternate repo on Centos/RHEL
+nginx_enablerepo: ""
+
 # The name of the nginx package to install.
 nginx_package_name: "nginx"
 

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -12,3 +12,4 @@
   yum:
     name: "{{ nginx_package_name }}"
     state: present
+    enablerepo: "{{ nginx_enablerepo }}"


### PR DESCRIPTION
Following the pattern you used in the php role, this simply adds the `nginx_enablerepo` variable and a blank default for Centos\RHEL systems.