### PR TITLE
Fix archlinux bug with pid

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,7 +1,9 @@
 user  {{ nginx_user }};
 
 error_log  {{ nginx_error_log }};
+{% if nginx_pidfile %}
 pid        {{ nginx_pidfile }};
+{% endif %}
 
 {% block worker %}
 worker_processes  {{ nginx_worker_processes }};

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -3,7 +3,7 @@ root_group: root
 nginx_conf_path: /etc/nginx/conf.d
 nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
-nginx_pidfile: /run/nginx.pid
+nginx_pidfile:
 nginx_vhost_path: /etc/nginx/sites-enabled
 nginx_default_vhost_path: /etc/nginx/sites-enabled/default
 __nginx_user: "http"


### PR DESCRIPTION
Because the pid is set in the service, setting it in the config file result in
an error. See https://bugs.archlinux.org/task/46500