### PR TITLE
Change: loop over a given group to set upstream servers

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -29,7 +29,7 @@ http {
 
     client_max_body_size {{ nginx_client_max_body_size }};
 
-    log_format  main  {{ nginx_log_format|indent(23) }};
+    log_format  main  {{ nginx_log_format|indent(23) }}
 
     access_log  {{ nginx_access_log }};
 
@@ -60,9 +60,15 @@ http {
 {% if upstream.strategy is defined %}
         {{ upstream.strategy }};
 {% endif %}
+{% if upstream.group is defined %}
+{% for host in groups[upstream.group] %}
+        server {{ hostvars[host]['ansible_default_ipv4']['address'] }}{% if upstream.port is defined %}:{{ upstream.port }}{% endif %};
+{% endfor %}
+{% else %}
 {% for server in upstream.servers %}
         server {{ server }};
 {% endfor %}
+{% endif %}
 {% if upstream.keepalive is defined %}
         keepalive {{ upstream.keepalive }};
 {% endif %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -29,7 +29,7 @@ http {
 
     client_max_body_size {{ nginx_client_max_body_size }};
 
-    log_format  main  {{ nginx_log_format|indent(23) }}
+    log_format  main  {{ nginx_log_format|indent(23) }};
 
     access_log  {{ nginx_access_log }};
 


### PR DESCRIPTION
- fix #165
- introduce a sub variable nginx_upstreams.group
- introduce a sub variable nginx_upstreams.port
- if upstream.group is define, it'll loop over a given group
- if upstream.group isn't define, upstream.servers is still mandatory
- the user can set an optional port at nginx_upstreams.port