### PR TITLE
Retry update apt cache task

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -2,6 +2,10 @@
 - name: Update apt cache.
   apt: update_cache=yes cache_valid_time=86400
   changed_when: false
+  register: command_result
+  retries: 20
+  delay: 10
+  until: command_result | success
 
 - name: Ensure nginx is installed.
   apt:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,7 +3,7 @@
   apt: update_cache=yes cache_valid_time=86400
   changed_when: false
   register: command_result
-  retries: 20
+  retries: 10
   delay: 10
   until: command_result | success
 


### PR DESCRIPTION
Sometimes `Update apt cache.` tasks fails in AWS. It happens sporadically. Retrying couple of times usually helps. To my knowledge, it's probably because of some kind of network level apt cache in AWS environment. If there is better way to solve this, I'm open for ideas. Otherwise, this dirty trick will do the work.