### PR TITLE
Add support to define the log level for the error log within a virtual host

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ A list of vhost definitions (server blocks) for Nginx virtual hosts. Each entry 
           ssl_protocols       TLSv1.1 TLSv1.2;
           ssl_ciphers         HIGH:!aNULL:!MD5;
 
+The configure a custom error log for a virtual host you can define the log-file and optionally the level, for example 
+
+    error_log: "/var/log/nginx/example.com.error.log warn" 
+
 An example of a fully-populated nginx_vhosts entry, using a `|` to declare a block of syntax for the `extra_parameters`.
 
 Please take note of the indentation in the above block. The first line should be a normal 2-space indent. All other lines should be indented normally relative to that line. In the generated file, the entire block will be 4-space indented. This style will ensure the config file is indented correctly.

--- a/templates/vhost.j2
+++ b/templates/vhost.j2
@@ -31,7 +31,7 @@ server {
     access_log {{ item.access_log }};
 {% endif %}
 {% if item.error_log is defined %}
-    error_log {{ item.error_log }} error;
+    error_log {{ item.error_log }};
 {% endif %}
 
 {% if item.return is defined %}


### PR DESCRIPTION
This change should be backward compatible, since the error_log directive will use `error` when the level parameter is omitted according to the documentation on http://nginx.org/en/docs/ngx_core_module.html#error_log.

By removing error in the templates/vhost.j2 template the behavior will be the same for existing configurations, since they cannot define the level with the current version.

The user can now define the level, for example ` error_log: "/var/log/nginx/example.com.error.log warn"`

