### PR TITLE
added the possibility of adding more log_format rows

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,3 +85,5 @@ nginx_log_format: |-
   '$remote_addr - $remote_user [$time_local] "$request" '
   '$status $body_bytes_sent "$http_referer" '
   '"$http_user_agent" "$http_x_forwarded_for"'
+
+nginx_log_format_extra: ""

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -31,6 +31,8 @@ http {
 
     log_format  main  {{ nginx_log_format|indent(23) }};
 
+    {{ nginx_log_format_extra }}
+
     access_log  {{ nginx_access_log }};
 
     sendfile        {{ nginx_sendfile }};


### PR DESCRIPTION
I have the need to add extra log_format entries apart from the main at http level. For example:

`log_format postdata $request_body;`