### PR TITLE
Add ASSUME_ALWAYS_YES in FreeBSD pkg update

### DIFF
--- a/tasks/setup-FreeBSD.yml
+++ b/tasks/setup-FreeBSD.yml
@@ -1,6 +1,8 @@
 ---
 - name: Update pkg cache.
   command: pkg update -f
+  environment:
+    ASSUME_ALWAYS_YES: yes
   tags: ['skip_ansible_lint']
 
 - name: Ensure nginx is installed.


### PR DESCRIPTION
This avoids the below waiting:

```
dbaio@freebsd13current:~ % sudo pkg update -f
Updating FreeBSD repository catalogue...
Fetching meta.txz: 100%    940 B   0.9kB/s    00:01    
Fetching packagesite.txz: 100%    6 MiB   2.2MB/s    00:03    
Processing entries:   0%
Newer FreeBSD version for package goobox:
To ignore this error set IGNORE_OSVERSION=yes
- package: 1300033
- running kernel: 1300032
Ignore the mismatch and continue? [Y/n]: 
```

which can happen in development systems.