### PR TITLE
Change ubuntu installation to always install nginx

### DIFF
--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -11,5 +11,4 @@
   apt:
     name: nginx
     state: absent
-  when: nginx_ppa_added.changed
   tags: ['skip_ansible_lint']


### PR DESCRIPTION
currently the nginx package is only installed if the ppa is added, this change will always install nginx even if ppa already exists.