### PR TITLE
nginx_conf tag added to simply update nginx config

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,8 @@
 # Variable setup.
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
+  tags:
+    - nginx_conf
 
 - name: Define nginx_user.
   set_fact:
@@ -40,6 +42,7 @@
     mode: 0644
   notify:
     - reload nginx
+    - nginx_conf
 
 - name: Ensure nginx service is running as configured.
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,7 @@
     mode: 0644
   notify:
     - reload nginx
+  tags:
     - nginx_conf
 
 - name: Ensure nginx service is running as configured.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,8 @@
   set_fact:
     nginx_user: "{{ __nginx_user }}"
   when: nginx_user is not defined
+  tags:
+    - nginx_conf
 
 # Setup/install tasks.
 - include_tasks: setup-RedHat.yml

--- a/tasks/vhosts.yml
+++ b/tasks/vhosts.yml
@@ -25,6 +25,7 @@
   notify: reload nginx
   tags:
     - skip_ansible_lint
+    - nginx_conf
 
 - name: Remove managed vhost config files.
   file:


### PR DESCRIPTION
It's very convenient to use tags to limit role's tasks to just what you want, e.g. update configuration. So that after changing some variables in group_vars/... I can just run:

ansible-playbook site.yml -l nginx_servers -t nginx_conf
