### PR TITLE
Add default for nginx.conf file permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ See the template in `templates/nginx.conf.j2` for more details on the placement.
 
 Configures Nginx's [`log_format`](http://nginx.org/en/docs/http/ngx_http_log_module.html#log_format). options.
 
+    nginx_conf_file_permission: "0644"
+
+Set the `nginx.conf` file permission mode.
+
+
     nginx_default_release: ""
 
 (For Debian/Ubuntu only) Allows you to set a different repository for the installation of Nginx. As an example, if you are running Debian's wheezy release, and want to get a newer version of Nginx, you can install the `wheezy-backports` repository and set that value here, and Ansible will use that as the `-t` option while installing Nginx.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,8 @@ nginx_service_enabled: true
 nginx_conf_template: "nginx.conf.j2"
 nginx_vhost_template: "vhost.j2"
 
+nginx_conf_file_permission: "0644"
+
 nginx_worker_processes: >-
   "{{ ansible_processor_vcpus | default(ansible_processor_count) }}"
 nginx_worker_connections: "1024"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
     dest: "{{ nginx_conf_file_path }}"
     owner: root
     group: "{{ root_group }}"
-    mode: 0644
+    mode: "{{ nginx_conf_file_permission }}"
   notify:
     - reload nginx
 


### PR DESCRIPTION
The dev-sec.nginx-hardening role adapts the file permission mode for
/etc/nginx with:

mode: o-rw

To have not everytime a changed state, the mode should be
configurable in this role as well.