### PR TITLE
Fix documented example value for nginx_upstreams.servers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,11 +78,10 @@ nginx_upstreams: []
 # - name: myapp1
 #   strategy: "ip_hash" # "least_conn", etc.
 #   keepalive: 16 # optional
-#   servers: {
-#     "srv1.example.com",
-#     "srv2.example.com weight=3",
-#     "srv3.example.com"
-#   }
+#   servers:
+#     - "srv1.example.com"
+#     - "srv2.example.com weight=3"
+#     - "srv3.example.com"
 
 nginx_log_format: |-
   '$remote_addr - $remote_user [$time_local] "$request" '


### PR DESCRIPTION
This converts the example value of nginx_upstreams.servers to a simple list of backends instead of using the unusual object syntax.