### PR TITLE
Add nginx.org debian repo as package source

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ Configures Nginx's [`log_format`](http://nginx.org/en/docs/http/ngx_http_log_mod
 
 (For Debian/Ubuntu only) Allows you to set a different repository for the installation of Nginx. As an example, if you are running Debian's wheezy release, and want to get a newer version of Nginx, you can install the `wheezy-backports` repository and set that value here, and Ansible will use that as the `-t` option while installing Nginx.
 
+    nginx_debian_repo_enabled: false
+    nginx_debian_repo_flavour: stable
+
+(For Debian only) Allows you to use the official Nginx Repo instead of the system's package. You can set the flavour to `stable` or `mainline`.
+
     nginx_ppa_use: false
     nginx_ppa_version: stable
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,10 @@ nginx_yum_repo_enabled: true
 nginx_ppa_use: false
 nginx_ppa_version: stable
 
+# Use the official Nginx Repo for Debian, and decide between "stable" and "mainline"
+nginx_debian_repo_enabled: false
+nginx_debian_repo_flavour: stable
+
 # The name of the nginx package to install.
 nginx_package_name: "nginx"
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,35 @@
 ---
+- name: Ensure APT official nginx key
+  apt_key:
+    url: 'http://nginx.org/keys/nginx_signing.key'
+    state: present
+  when: nginx_debian_repo_enabled | bool
+
+- name: Ensure APT official nginx repository
+  apt_repository:
+    repo: 'deb http://nginx.org/packages/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} nginx'
+    state: present
+    filename: nginx
+    update_cache: true
+  register: nginx_repo_added
+  when: nginx_debian_repo_enabled | bool and nginx_debian_repo_flavour == "stable"
+
+- name: Ensure APT official nginx repository (mainline)
+  apt_repository:
+    repo: 'deb http://nginx.org/packages/mainline/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} nginx'
+    state: present
+    filename: nginx
+    update_cache: true
+  register: nginx_repo_added
+  when: nginx_debian_repo_enabled | bool and nginx_debian_repo_flavour == "mainline"
+
+- name: Ensure nginx will reinstall if the PPA was just added.
+  apt:
+    name: nginx
+    state: absent
+  when: nginx_repo_added is changed
+  tags: ['skip_ansible_lint']
+
 - name: Update apt cache.
   apt: update_cache=yes cache_valid_time=86400
   changed_when: false

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -23,7 +23,7 @@
   register: nginx_repo_added
   when: nginx_debian_repo_enabled | bool and nginx_debian_repo_flavour == "mainline"
 
-- name: Ensure nginx will reinstall if the PPA was just added.
+- name: Ensure nginx will reinstall if the repo was just added.
   apt:
     name: nginx
     state: absent


### PR DESCRIPTION
I noticed Ubuntu has an PPA possibility but debian not. Currently the version in buster is quite old so i like to use some newer version without switching to ubuntu e.g.
