### PR TITLE
Add support for Clear Linux OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 **Note:** Please consider using the official [NGINX Ansible role](https://github.com/nginxinc/ansible-role-nginx) from NGINX, Inc.
 
-Installs Nginx on RedHat/CentOS, Debian/Ubuntu, Archlinux, FreeBSD or OpenBSD servers.
+Installs Nginx on RedHat/CentOS, Debian/Ubuntu, Archlinux, Clear Linux OS, FreeBSD or OpenBSD servers.
 
-This role installs and configures the latest version of Nginx from the Nginx yum repository (on RedHat-based systems), apt (on Debian-based systems), pacman (Archlinux), pkgng (on FreeBSD systems) or pkg_add (on OpenBSD systems). You will likely need to do extra setup work after this role has installed Nginx, like adding your own [virtualhost].conf file inside `/etc/nginx/conf.d/`, describing the location and options to use for your particular website.
+This role installs and configures the latest version of Nginx from the Nginx yum repository (on RedHat-based systems), apt (on Debian-based systems), pacman (Archlinux), swupd (on Clear Linux OS), pkgng (on FreeBSD systems) or pkg_add (on OpenBSD systems). You will likely need to do extra setup work after this role has installed Nginx, like adding your own [virtualhost].conf file inside `/etc/nginx/conf.d/`, describing the location and options to use for your particular website.
 
 ## Requirements
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,6 +25,9 @@ galaxy_info:
     - name: Archlinux
       versions:
         - all
+    - name: ClearLinux
+      versions:
+        - all
     - name: FreeBSD
       versions:
         - 10.3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,9 @@
 - include_tasks: setup-Archlinux.yml
   when: ansible_os_family == 'Archlinux'
 
+- include_tasks: setup-ClearLinux.yml
+  when: ansible_os_family == 'ClearLinux'
+
 # Vhost configuration.
 - import_tasks: vhosts.yml
 

--- a/tasks/setup-ClearLinux.yml
+++ b/tasks/setup-ClearLinux.yml
@@ -1,0 +1,5 @@
+---
+- name: Ensure nginx is installed.
+  swupd:
+    name: "{{ nginx_package_name }}"
+    state: present

--- a/vars/ClearLinux.yml
+++ b/vars/ClearLinux.yml
@@ -1,0 +1,9 @@
+---
+root_group: wheel
+nginx_conf_path: /etc/nginx/conf.d
+nginx_conf_file_path: /etc/nginx/nginx.conf
+nginx_mime_file_path: /usr/share/nginx/conf/mime.types
+nginx_pidfile: /run/nginx.pid
+nginx_vhost_path: /etc/nginx/sites-enabled
+nginx_default_vhost_path: /etc/nginx/sites-enabled/default
+__nginx_user: "httpd"


### PR DESCRIPTION
Everything seems to work fine, although `nginx_default_vhost_path` has no equivalent in Clear Linux as far as I can see: nginx is configured with no vhosts at all by default. I used a fictitious path for that variable.