### PR TITLE
Justify handler orders

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
-- name: restart nginx
-  service: name=nginx state=restarted
-
 - name: validate nginx configuration
   command: nginx -t -c /etc/nginx/nginx.conf
   changed_when: false
 
 - name: reload nginx
   service: name=nginx state=reloaded
+
+- name: restart nginx
+  service: name=nginx state=restarted


### PR DESCRIPTION
Orders of handlers may become relevant and config validation should be executed before restarting the service.