### PR TITLE
nginx_service_name variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ nginx_ppa_version: stable
 # The name of the nginx package to install.
 nginx_package_name: "nginx"
 
+nginx_service_name: "nginx"
 nginx_service_state: started
 nginx_service_enabled: true
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,10 +1,14 @@
 ---
 - name: restart nginx
-  service: name=nginx state=restarted
+  service:
+    name: "{{ nginx_service_name }}"
+    state: restarted
 
 - name: validate nginx configuration
-  command: nginx -t -c /etc/nginx/nginx.conf
+  command: "{{ nginx_service_name }} -t -c /etc/nginx/nginx.conf"
   changed_when: false
 
 - name: reload nginx
-  service: name=nginx state=reloaded
+  service:
+    name: "{{ nginx_service_name }}"
+    state: reloaded

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,6 @@
 
 - name: Ensure nginx service is running as configured.
   service:
-    name: nginx
+    name: "{{ nginx_service_name }}"
     state: "{{ nginx_service_state }}"
     enabled: "{{ nginx_service_enabled }}"


### PR DESCRIPTION
Added `nginx_service_name` variable so this role could be used with **openresty** (after setting up a repo, `nginx_package_name: openresty` and adding a few symlinks).