### PR TITLE
Feature: Add send_timeout to template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,10 +30,12 @@ nginx_sendfile: "on"
 nginx_tcp_nopush: "on"
 nginx_tcp_nodelay: "on"
 
-nginx_keepalive_timeout: "65"
+nginx_keepalive_timeout: "10"
 nginx_keepalive_requests: "100"
 
-nginx_server_tokens: "on"
+nginx_send_timeout: "10"
+
+nginx_server_tokens: "off"
 
 nginx_client_max_body_size: "64m"
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -48,9 +48,7 @@ http {
 {% endif %}
 {% endblock %}
 
-{% block http_gzip %}
-    # gzip on;
-{% endblock %}
+{% block http_gzip %}{% endblock %}
 
 {% if nginx_extra_http_options %}
     {{ nginx_extra_http_options|indent(4, False) }}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -19,7 +19,7 @@ events {
 {% endblock %}
 
 http {
-    {% block http_begin %}{% endblock %}
+{% block http_begin %}{% endblock %}
 
 {% block http_basic %}
     include       {{ nginx_mime_file_path }};
@@ -79,5 +79,5 @@ http {
 {% endif %}
 {% endblock %}
 
-    {% block http_end %}{% endblock %}
+{% block http_end %}{% endblock %}
 }

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -40,6 +40,8 @@ http {
     keepalive_timeout  {{ nginx_keepalive_timeout }};
     keepalive_requests {{ nginx_keepalive_requests }};
 
+    send_timeout {{ nginx_send_timeout }};
+
     server_tokens {{ nginx_server_tokens }};
 {% if nginx_proxy_cache_path %}
     proxy_cache_path {{ nginx_proxy_cache_path }};


### PR DESCRIPTION
- Adds `nginx_send_timeout` variable with default of `10` to mitigate denial of service
- Modify `nginx_keepalive_timeout` variable with default of `10` to mitigate denial of service
- Modify `nginx_server_tokens` variable with default of `off` to mitigate security scans
- Remove indentation on `http_begin` and more importantly `http_end` block to avoid odd `    }` spacing at the end of the config when block is not used