### PR TITLE
change fixed apt package name to var nginx_package_name

### DIFF
--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -14,7 +14,7 @@
 
 - name: Ensure nginx will reinstall if the PPA was just added.
   apt:
-    name: nginx
+    name: "{{ nginx_package_name }}"
     state: absent
   when: nginx_ppa_added is changed
   tags: ['skip_ansible_lint']


### PR DESCRIPTION
In one task (tasks/setup-Ubuntu.yml), looks like it was forgotten to change the name of package to the variable. I fixed it.