### PR TITLE
Add extra_vhost_header, which allows to add lines outside of server{}

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ A list of vhost definitions (server blocks) for Nginx virtual hosts. Each entry 
         template: "{{ nginx_vhost_template }}"
         filename: "example.com.conf"
         extra_parameters: |
+          if ($good_user = 0) {
+              rewrite ^/page/to/be/hidden/for/public.html$ /index.html;
+          }
           location ~ \.php$ {
               fastcgi_split_path_info ^(.+\.php)(/.+)$;
               fastcgi_pass unix:/var/run/php5-fpm.sock;
@@ -49,8 +52,15 @@ A list of vhost definitions (server blocks) for Nginx virtual hosts. Each entry 
           ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
           ssl_protocols       TLSv1.1 TLSv1.2;
           ssl_ciphers         HIGH:!aNULL:!MD5;
+        extra_vhost_header: |
+          geo $good_user {
+              default 0;
+              10.0.0.0/8 1;
+              192.168.0.0/16 1;
+              172.16.0.0/12 1;
+          }
 
-An example of a fully-populated nginx_vhosts entry, using a `|` to declare a block of syntax for the `extra_parameters`.
+An example of a fully-populated nginx_vhosts entry, using a `|` to declare a block of syntax for the `extra_parameters` and for `extra_vhost_header`.
 
 Please take note of the indentation in the above block. The first line should be a normal 2-space indent. All other lines should be indented normally relative to that line. In the generated file, the entire block will be 4-space indented. This style will ensure the config file is indented correctly.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,10 @@ nginx_vhosts: []
 #   extra_parameters: "" # Can be used to add extra config blocks (multiline).
 #   template: "" # Can be used to override the `nginx_vhost_template` per host.
 #   state: "absent" # To remove the vhost configuration.
+#   extra_vhost_header: ""  # Can be used to add extra config blocks (multiline) to
+#                           # the beginning of the vhost file, outside of the
+#                           # server {} block
+
 
 nginx_upstreams: []
 # - name: myapp1

--- a/templates/vhost.j2
+++ b/templates/vhost.j2
@@ -1,3 +1,9 @@
+{% block vhost_header %}
+{% if item.extra_vhost_header is defined %}
+{{ item.extra_vhost_header }}
+{% endif %}
+{% endblock %}
+
 {% block server_redirect %}
 {% if item.server_name_redirect is defined %}
 server {


### PR DESCRIPTION
This patch allows to have a vhost variable extra_vhost_header, which can be filled if configuration lines are needed to
be injected before the server {} block inside a vhost.

You need this for example if you like to use the "geo"-module
