### PR TITLE
fix(handler):not run handler when nginx_service_state stopped

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,3 +8,4 @@
 
 - name: reload nginx
   service: name=nginx state=reloaded
+  when: nginx_service_state == "started"


### PR DESCRIPTION
If we use the role with variable `nginx_service_state: "stopped"`, the handler shouldn't run.