### PR TITLE
Fix nginx service failing to run on Archlinux

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,7 +1,9 @@
 user  {{ nginx_user }};
 
 error_log  {{ nginx_error_log }};
+{% if nginx_pidfile is defined and nginx_pidfile|d('')|length > 0 %}
 pid        {{ nginx_pidfile }};
+{% endif %}
 
 {% block worker %}
 worker_processes  {{ nginx_worker_processes }};

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -3,7 +3,7 @@ root_group: root
 nginx_conf_path: /etc/nginx/conf.d
 nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
-nginx_pidfile: /run/nginx.pid
+nginx_pidfile: ""
 nginx_vhost_path: /etc/nginx/sites-enabled
 nginx_default_vhost_path: /etc/nginx/sites-enabled/default
 __nginx_user: "http"


### PR DESCRIPTION
The nginx service on archlinux has `ExecStart=/usr/bin/nginx -g 'pid /run/nginx.pid; error_log stderr;'`in its service file. As a result when trying to run the systemd service for nginx the service reports `"pid" directive is duplicate in /etc/nginx/nginx.conf:4`

This has been 'fixed' by defaulting `{{ nginx_pidfile }}` to `""` only on Archlinux and adding a statement to remove its line when the variable is an empty string.

A better future workaround may be to modify ExecStart= with a systemd override, but whether that's a hack you would be inclined to accept into this project, is up to you.

Also I misphrased the commit message, please ignore.