### PR TITLE
set server_tokens to 'off' to prevent information disclosure.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,7 @@ nginx_tcp_nodelay: "on"
 nginx_keepalive_timeout: "75"
 nginx_keepalive_requests: "600"
 
-nginx_server_tokens: "on"
+nginx_server_tokens: "off"
 
 nginx_client_max_body_size: "64m"
 


### PR DESCRIPTION
Many NGINX hardening guides recommend to set the server_tokens to "off" to prevent information disclosure. 
Hiding the version number makes it a little more difficult for a potential hacker to select attack vectors for known vulnerabilities for a specifc NGINX version. 