### PR TITLE
enh: Allow default vhost path override

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ An example of a secondary vhost which will redirect to the one shown above.
 
     nginx_remove_default_vhost: false
 
-Whether to remove the 'default' virtualhost configuration supplied by Nginx. Useful if you want the base `/` URL to be directed at one of your own virtual hosts configured in a separate .conf file.
+Whether to remove the 'default' virtualhost configuration supplied by Nginx. Useful if you want the base `/` URL to be directed at one of your own virtual hosts configured in a separate .conf file. You can optionnaly set `nginx_override_default_vhost_path` if the default vhost file determined by distribution name is not the correct one (for example: since nginx 1.24 Debian package from nginx repository, vhost default file supplied is '/etc/nginx/conf.d/default.conf' instead of '/etc/nginx/sites-enabled/default' previously).
 
     nginx_upstreams: []
 

--- a/vars/AlmaLinux.yml
+++ b/vars/AlmaLinux.yml
@@ -5,5 +5,5 @@ nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
 nginx_pidfile: /var/run/nginx.pid
 nginx_vhost_path: /etc/nginx/conf.d
-nginx_default_vhost_path: /etc/nginx/conf.d/default.conf
+nginx_default_vhost_path: "{{ nginx_override_default_vhost_path | default('/etc/nginx/conf.d/default.conf') }}"
 __nginx_user: "nginx"

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -5,5 +5,5 @@ nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
 nginx_pidfile: /run/nginx.pid
 nginx_vhost_path: /etc/nginx/sites-enabled
-nginx_default_vhost_path: /etc/nginx/sites-enabled/default
+nginx_default_vhost_path: "{{ nginx_override_default_vhost_path | default('/etc/nginx/sites-enabled/default') }}"
 __nginx_user: "http"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,5 +5,5 @@ nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
 nginx_pidfile: /run/nginx.pid
 nginx_vhost_path: /etc/nginx/sites-enabled
-nginx_default_vhost_path: /etc/nginx/sites-enabled/default
+nginx_default_vhost_path: "{{ nginx_override_default_vhost_path | default('/etc/nginx/sites-enabled/default') }}"
 __nginx_user: "www-data"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -5,5 +5,7 @@ nginx_conf_file_path: /usr/local/etc/nginx/nginx.conf
 nginx_mime_file_path: /usr/local/etc/nginx/mime.types
 nginx_pidfile: /var/run/nginx.pid
 nginx_vhost_path: /usr/local/etc/nginx/sites-enabled
-nginx_default_vhost_path: "{{ nginx_override_default_vhost_path | default('/usr/local/etc/nginx/sites-enabled/default') }}"
+nginx_default_vhost_path: >
+  {{ nginx_override_default_vhost_path | 
+  default('/usr/local/etc/nginx/sites-enabled/default') }}
 __nginx_user: "www"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -5,5 +5,5 @@ nginx_conf_file_path: /usr/local/etc/nginx/nginx.conf
 nginx_mime_file_path: /usr/local/etc/nginx/mime.types
 nginx_pidfile: /var/run/nginx.pid
 nginx_vhost_path: /usr/local/etc/nginx/sites-enabled
-nginx_default_vhost_path: /usr/local/etc/nginx/sites-enabled/default
+nginx_default_vhost_path: "{{ nginx_override_default_vhost_path | default('/usr/local/etc/nginx/sites-enabled/default') }}"
 __nginx_user: "www"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -6,6 +6,6 @@ nginx_mime_file_path: /usr/local/etc/nginx/mime.types
 nginx_pidfile: /var/run/nginx.pid
 nginx_vhost_path: /usr/local/etc/nginx/sites-enabled
 nginx_default_vhost_path: >
-  {{ nginx_override_default_vhost_path | 
+  {{ nginx_override_default_vhost_path |
   default('/usr/local/etc/nginx/sites-enabled/default') }}
 __nginx_user: "www"

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -5,6 +5,6 @@ nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
 nginx_pidfile: /var/run/nginx.pid
 nginx_vhost_path: /etc/nginx/sites-enabled
-nginx_default_vhost_path: /etc/nginx/sites-enabled/default
+nginx_default_vhost_path: "{{ nginx_override_default_vhost_path | default('/etc/nginx/sites-enabled/default') }}"
 nginx_package_name: "nginx--"
 __nginx_user: "www"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,5 +5,5 @@ nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
 nginx_pidfile: /var/run/nginx.pid
 nginx_vhost_path: /etc/nginx/conf.d
-nginx_default_vhost_path: /etc/nginx/conf.d/default.conf
+nginx_default_vhost_path: "{{ nginx_override_default_vhost_path | default('/etc/nginx/conf.d/default.conf') }}"
 __nginx_user: "nginx"

--- a/vars/Rocky.yml
+++ b/vars/Rocky.yml
@@ -5,5 +5,5 @@ nginx_conf_file_path: /etc/nginx/nginx.conf
 nginx_mime_file_path: /etc/nginx/mime.types
 nginx_pidfile: /var/run/nginx.pid
 nginx_vhost_path: /etc/nginx/conf.d
-nginx_default_vhost_path: /etc/nginx/conf.d/default.conf
+nginx_default_vhost_path: "{{ nginx_override_default_vhost_path | default('/etc/nginx/conf.d/default.conf') }}"
 __nginx_user: "nginx"


### PR DESCRIPTION
Allow to use an alternative default vhost filename (to be able to remove it!).

Some distribution and/or package supplier changed the default vhost file over time.

For example in nginx 1.24 Debian package supplied by nginx.org, vhost default file supplied is now '/etc/nginx/conf.d/default.conf' instead of '/etc/nginx/sites-enabled/default' previously.

just set variable nginx_override_default_vhost_path accordingly.

if nginx_override_default_vhost_path is not set nothing changes.